### PR TITLE
Improve detection of submodule at requested prelude-submodule path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,12 +50,27 @@ runs:
       if: inputs.prelude-submodule != ''
       shell: bash
 
-    - run: |
-        if ! git submodule status -- "${{inputs.prelude-submodule}}" &>/dev/null; then
-          rmdir -- "${{inputs.prelude-submodule}}"
-          git submodule add -- https://github.com/facebook/buck2-prelude "${{inputs.prelude-submodule}}"
+    - id: uninitialized-submodule
+      run: |
+        if git submodule status | grep -q ' \./$'; then
+          echo is-submodule=true >> $GITHUB_OUTPUT
         fi
+      working-directory: ${{inputs.prelude-submodule}}
       if: inputs.prelude-submodule != ''
+      shell: bash
+
+    - id: initialized-submodule
+      run: |
+        if ! diff -q <(cd -- "${{inputs.prelude-submodule}}"; git rev-parse --git-dir) <(cd -- "${{inputs.prelude-submodule}}"/..; git rev-parse --git-dir) >/dev/null; then
+          echo is-submodule=true >> $GITHUB_OUTPUT
+        fi
+      if: inputs.prelude-submodule != '' && !steps.uninitialized-submodule.outputs.is-submodule
+      shell: bash
+
+    - run: |
+        rmdir -- "${{inputs.prelude-submodule}}"
+        git submodule add -- https://github.com/facebook/buck2-prelude "${{inputs.prelude-submodule}}"
+      if: inputs.prelude-submodule != '' && !steps.uninitialized-submodule.outputs.is-submodule && !steps.initialized-submodule.outputs.is-submodule
       shell: bash
 
     - run: git submodule update --init --remote -- "${{inputs.prelude-submodule}}"


### PR DESCRIPTION
The previous code (`if ! git submodule status -- "${{inputs.prelude-submodule}}" &>/dev/null`) correctly distinguished between whether `prelude-submodule` was already registered as a submodule vs was a non-existent directory. Only in the latter case would it execute `git submodule add`.

However if `prelude-submodule` was an existing directory (with or without any contents in it) that was not a submodule, then `git submodule status` would exit 0 and `git submodule add` would incorrectly not run. This would lead to a failure later at `git checkout` saying _"fatal: reference is not a tree"_ after looking up the buck2-prelude's commit hash as if it were a commit hash in the superproject.

This PR adds 2 new heuristics for detecting whether `prelude-submodule` is an uninitialized submodule (based on whether `./` is listed in the output of `git submodule status` when run from that directory) or initialized submodule (based on whether `git rev-parse --git-dir` produces different output in that directory vs its parent directory).