### PR TITLE
Fix detection of submodule that is immediate subdirectory of repo root

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - id: initialized-submodule
       run: |
-        if ! diff -q <(cd -- "${{inputs.prelude-submodule}}"; git rev-parse --git-dir) <(cd -- "${{inputs.prelude-submodule}}"/..; git rev-parse --git-dir) >/dev/null; then
+        if ! diff -q <(cd -- "${{inputs.prelude-submodule}}"; git rev-parse --absolute-git-dir) <(cd -- "${{inputs.prelude-submodule}}"/..; git rev-parse --absolute-git-dir) >/dev/null; then
           echo is-submodule=true >> $GITHUB_OUTPUT
         fi
       if: inputs.prelude-submodule != '' && !steps.uninitialized-submodule.outputs.is-submodule


### PR DESCRIPTION
`git rev-parse --git-dir` returns a relative path if called from the repo root, and an absolute path if called from any other directory. So comparing `git rev-parse --git-dir` between the submodule and its parent directory worked only as long as the parent directory was not the repo root.