### PR TITLE
Disregard lld install failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
 
     - run: sudo apt-get install lld
       if: runner.os == 'Linux'
+      continue-on-error: true
       shell: bash
 
     - run: buck2 --version


### PR DESCRIPTION
Closes #8. Repos that need to support act runner and need lld can figure out how to install it a different way.