### PR TITLE
Support installing a specific buck2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ jobs:
     executable.
   </td>
 </tr>
+<tr>
+  <td><pre>release</pre></td>
+  <td>
+    Optional. Release tag of the
+    <a href="https://github.com/facebook/buck2">buck2</a>
+    repo to install.
+  </td>
+</tr>
 </table>
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   color: purple
 
 inputs:
+  release:
+    description: Optional Buck2 release tag. If omitted, installs the latest release.
+    required: false
+    default: 'latest'
   prelude-submodule:
     description: Path to checkout https://github.com/facebook/buck2-prelude as a submodule
     required: false
@@ -27,11 +31,11 @@ runs:
     - run: mkdir -p "${{runner.temp}}/install-buck2/bin"
       shell: bash
 
-    - run: curl https://github.com/facebook/buck2/releases/download/latest/buck2-${{steps.configure.outputs.platform}}${{steps.configure.outputs.extension}}.zst --output "${{runner.temp}}/install-buck2/buck2${{steps.configure.outputs.extension}}.zst" --location --silent --show-error --fail --retry 5
+    - run: curl https://github.com/facebook/buck2/releases/download/${{inputs.release}}/buck2-${{steps.configure.outputs.platform}}${{steps.configure.outputs.extension}}.zst --output "${{runner.temp}}/install-buck2/buck2${{steps.configure.outputs.extension}}.zst" --location --silent --show-error --fail --retry 5
       shell: bash
 
     - id: prelude-hash
-      run: curl https://github.com/facebook/buck2/releases/download/latest/prelude_hash --location --silent --show-error --fail --retry 5 | sed 's/^/prelude-hash=/' >> $GITHUB_OUTPUT
+      run: curl https://github.com/facebook/buck2/releases/download/${{inputs.release}}/prelude_hash --location --silent --show-error --fail --retry 5 | sed 's/^/prelude-hash=/' >> $GITHUB_OUTPUT
       shell: bash
 
     - run: zstd -d "${{runner.temp}}/install-buck2/buck2${{steps.configure.outputs.extension}}.zst" -o "${{runner.temp}}/install-buck2/bin/buck2${{steps.configure.outputs.extension}}"


### PR DESCRIPTION
## Reason for Change

The current action implementation allows for facebook to release a new `latest` software, and subsequently breaking downstream action consumers based on `buck2` version incompatibility (prelude included).

## Description of Change

- Support a `release` variable which defaults to `latest`
- Document the action input

## Test Plan

- Run action with release specified, ensure the right build is installed ✅ 
- Ensure the `buck2` build succeeds (this was previously passing in our repo) ✅ 
 
<img width="1397" height="606" alt="Screenshot 2026-03-14 at 12 39 17 AM" src="https://github.com/user-attachments/assets/c7ecfac4-ff6b-4022-b746-91cd0fd6590d" />